### PR TITLE
Potential fix for code scanning alert no. 18: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/java/org/apache/jasper/servlet/JspCServletContext.java
+++ b/java/org/apache/jasper/servlet/JspCServletContext.java
@@ -404,7 +404,12 @@ public class JspCServletContext implements ServletContext {
                             int sep = entryName.indexOf('/', jarPath.length());
                             if (sep < 0) {
                                 // This is a file - strip leading "META-INF/resources"
-                                thePaths.add(entryName.substring(18));
+                                String sanitizedEntryName = entryName.substring(18);
+                                File testFile = new File(basePath, sanitizedEntryName);
+                                if (!testFile.toPath().normalize().startsWith(new File(basePath).toPath())) {
+                                    throw new IOException("Invalid entry path: " + sanitizedEntryName);
+                                }
+                                thePaths.add(sanitizedEntryName);
                             } else {
                                 // This is a directory - strip leading "META-INF/resources"
                                 thePaths.add(entryName.substring(18, sep + 1));

--- a/java/org/apache/tomcat/util/scan/JarFileUrlJar.java
+++ b/java/org/apache/tomcat/util/scan/JarFileUrlJar.java
@@ -189,7 +189,11 @@ public class JarFileUrlJar implements Jar {
         if (entry == null) {
             return null;
         } else {
-            return entry.getName();
+            String sanitizedName = entry.getName();
+            if (sanitizedName.contains("..") || sanitizedName.startsWith("/") || sanitizedName.startsWith("\\")) {
+                throw new IOException("Invalid entry name: " + sanitizedName);
+            }
+            return sanitizedName;
         }
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/tomcat/security/code-scanning/18](https://github.com/codeallthethingsbreak/tomcat/security/code-scanning/18)

To fix the issue, we need to ensure that paths derived from `entry.getName()` are validated to prevent directory traversal attacks. This involves:
1. Normalizing the path using `java.nio.file.Path.normalize()` or `java.io.File.getCanonicalFile()` to resolve any `../` or similar elements.
2. Verifying that the normalized path starts with the intended base directory using `java.nio.file.Path.startsWith()`.

The fix should be applied in the `JarFileUrlJar` class where `entry.getName()` is used, and in the `JspCServletContext` class where `entryName` is processed. Specifically:
- In `JarFileUrlJar`, sanitize the output of `entry.getName()` before returning it in `getEntryName()`.
- In `JspCServletContext`, validate `entryName` before adding it to `thePaths`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
